### PR TITLE
feat(title): make it possible to specify the title

### DIFF
--- a/example/docs/doc1.md
+++ b/example/docs/doc1.md
@@ -11,6 +11,10 @@ This theme provides the following:
 https://github.com/saucelabs/docusaurus-theme-github-codeblock/blob/main/src/theme/ReferenceCodeBlock/index.tsx#L104-L107
 ```
 
+```js reference title="Custom Title"
+https://github.com/saucelabs/docusaurus-theme-github-codeblock/blob/main/src/theme/ReferenceCodeBlock/index.tsx#L104-L107
+```
+
 You can write content using [GitHub-flavored Markdown syntax](https://github.github.com/gfm/).
 
 ## Markdown Syntax

--- a/src/theme/ReferenceCodeBlock/index.tsx
+++ b/src/theme/ReferenceCodeBlock/index.tsx
@@ -109,11 +109,15 @@ function ReferenceCode(props: ReferenceCodeBlockProps) {
         fetchCode(codeSnippetDetails, fetchResultStateDispatcher)
     }
 
+    const titleMatch = props.metastring?.match(/title="(?<title>.*)"/);
+
     const customProps = {
         ...props,
-        metastring: ` title="${codeSnippetDetails.title}"`,
-        children: initialFetchResultState.code
-    }
+        metastring: titleMatch?.groups?.title
+            ? ` title="${titleMatch?.groups?.title}"`
+            : ` title="${codeSnippetDetails.title}"`,
+        children: initialFetchResultState.code,
+    };
 
     return (
         <div>


### PR DESCRIPTION
Hello there

I'm not familiar with react, so if I did this totally wrong, let me know 👍 

## Usage


> \```js reference title="Instantiation"
> https://github.com/ERC725Alliance/erc725.js/blob/feature/simplify-api/examples/decodeData/index.js#L1-L45
> \```

<img width="880" alt="Screenshot 2021-08-03 at 14 09 43" src="https://user-images.githubusercontent.com/798709/128013003-5ed0eee6-e586-47bf-9878-f75054008b5e.png">

Closes #11 