### PR TITLE
Supports Docusaurus 3

### DIFF
--- a/src/theme/CodeBlock/index.tsx
+++ b/src/theme/CodeBlock/index.tsx
@@ -13,7 +13,7 @@ import type { ReferenceCodeBlockProps } from '../types'
 
 const componentWrapper = (Component: typeof CodeBlock) => {
   const WrappedComponent = (props: ReferenceCodeBlockProps) => {
-    if (props.reference) {
+    if (props.reference || props.metastring?.split(' ').includes('reference')) {
       return (
         <ReferenceCodeBlock {...props} />
       );


### PR DESCRIPTION
# One-line summary

Added support for Docusaurus 3

> Issue : #88

## Description
Added props.metastring support for newer react versions (docusaurus 3)
keeps backwards compatibility with older react and docusaurus 2

## Types of Changes
_What types of changes does your code introduce? Keep the ones that apply:_

- New feature (non-breaking change which adds functionality)
